### PR TITLE
fixes dispatcher test that inadvertently access db

### DIFF
--- a/awx/main/tests/functional/conftest.py
+++ b/awx/main/tests/functional/conftest.py
@@ -8,6 +8,7 @@ import tempfile
 import shutil
 from datetime import timedelta
 from six.moves import xrange
+from mock import PropertyMock
 
 # Django
 from django.core.urlresolvers import resolve
@@ -752,3 +753,8 @@ def sqlite_copy_expert(request):
     request.addfinalizer(lambda: delattr(SQLiteCursorWrapper, 'copy_expert'))
     return path
 
+
+@pytest.fixture
+def disable_database_settings(mocker):
+    m = mocker.patch('awx.conf.settings.SettingsWrapper.all_supported_settings', new_callable=PropertyMock)
+    m.return_value = []

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -55,6 +55,7 @@ class SlowResultWriter(BaseWorker):
         super(SlowResultWriter, self).perform_work(body, result_queue)
 
 
+@pytest.mark.usefixtures("disable_database_settings")
 class TestPoolWorker:
 
     def setup_method(self, test_method):
@@ -247,6 +248,7 @@ class TestAutoScaling:
         assert len(self.pool) == 2
 
 
+@pytest.mark.usefixtures("disable_database_settings")
 class TestTaskDispatcher:
 
     @property


### PR DESCRIPTION
* Logger inadvertently triggered by dispatcher tests that do not need DB
access. Mock settings to sidestep DB access.