### PR TITLE
Add option to exclude hidden events

### DIFF
--- a/awx/main/migrations/0115_v370_gather_events.py
+++ b/awx/main/migrations/0115_v370_gather_events.py
@@ -13,11 +13,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='job',
             name='gather_event_types',
-            field=models.CharField(choices=[('all', 'All'), ('errors', 'Only events that contain errors'), ('none', 'Only Headers')], default='all', help_text='Filters certain events before they are written to the database. Events are still emitted to external loggers but their stdout will be hidden and the filtered events will not show up in the database. This field can be used to limit number of events recorded for extremely large jobs.', max_length=64),
+            field=models.CharField(choices=[('all', 'All'), ('errors', 'Only events that contain errors'), ('output', 'Only events that contain stdout or stderr output'), ('none', 'Only Headers')], default='all', help_text='Filters certain events before they are written to the database. Events are still emitted to external loggers but their stdout will be hidden and the filtered events will not show up in the database. This field can be used to limit number of events recorded for extremely large jobs.', max_length=64),
         ),
         migrations.AddField(
             model_name='jobtemplate',
             name='gather_event_types',
-            field=models.CharField(choices=[('all', 'All'), ('errors', 'Only events that contain errors'), ('none', 'Only Headers')], default='all', help_text='Filters certain events before they are written to the database. Events are still emitted to external loggers but their stdout will be hidden and the filtered events will not show up in the database. This field can be used to limit number of events recorded for extremely large jobs.', max_length=64),
+            field=models.CharField(choices=[('all', 'All'), ('errors', 'Only events that contain errors'), ('output', 'Only events that contain stdout or stderr output'), ('none', 'Only Headers')], default='all', help_text='Filters certain events before they are written to the database. Events are still emitted to external loggers but their stdout will be hidden and the filtered events will not show up in the database. This field can be used to limit number of events recorded for extremely large jobs.', max_length=64),
         ),
     ]

--- a/awx/main/models/base.py
+++ b/awx/main/models/base.py
@@ -31,6 +31,7 @@ PERM_INVENTORY_SCAN   = 'scan'
 
 JOB_EVENTS_ALL = "all"
 JOB_EVENTS_ONLY_ERRORS = "errors"
+JOB_EVENTS_OUTPUT = "output"
 JOB_EVENTS_NONE = "none"
 
 JOB_TYPE_CHOICES = [
@@ -57,6 +58,7 @@ PROJECT_UPDATE_JOB_TYPE_CHOICES = [
 JOB_EVENTS_COLLECTED_CHOICES = [
     (JOB_EVENTS_ALL, _("All")),
     (JOB_EVENTS_ONLY_ERRORS, _("Only events that contain errors")),
+    (JOB_EVENTS_OUTPUT, _("Only events that contain stdout or stderr output")),
     (JOB_EVENTS_NONE, _("Only Headers")),
 ]
 

--- a/awx/main/tasks.py
+++ b/awx/main/tasks.py
@@ -1227,12 +1227,14 @@ class BaseTask(object):
                 event_data = json.loads(event_data_json)
             except json.JSONDecodeError:
                 pass
-        elif isinstance(self, RunJob) and self.instance.gather_event_types in ("none", "errors"):
+        elif isinstance(self, RunJob) and self.instance.gather_event_types != "all":
             event_level = BasePlaybookEvent._level_event(event_data.get("event"))
             failed = event_data.get("event") in BasePlaybookEvent.FAILED_EVENTS
             skip_save = event_level in [0,3]
             if self.instance.gather_event_types == "errors":
                 skip_save = skip_save and not failed
+            elif self.instance.gather_event_types == "output":
+                skip_save = skip_save and not event_data.get("stdout")
             event_data["skip_save"] = skip_save
 
         event_data.setdefault(self.event_data_key, self.instance.id)


### PR DESCRIPTION
Tested locally with the demo job template, and confirmed that the events produced reduces from 7 to 6, which removes the playbook_on_start event, as expected.